### PR TITLE
Add rate of change for rain

### DIFF
--- a/exercise2/app.R
+++ b/exercise2/app.R
@@ -16,8 +16,8 @@ ui <- fluidPage(
       selectInput('chemical', 'Chemical', choices = listOfChemicals()),
       dateRangeInput("date_range", 
                      "Date range",
-                     start = "2018-07-01", 
-                     end = as.character(Sys.Date())),
+                     start = startDate(),
+                     end = endDate()),
       checkboxInput('rain', 'Include rainfall', value = FALSE),
       checkboxInput('future', 'Predicut future values', value = FALSE)
     ),
@@ -41,7 +41,10 @@ server <- function(input, output) {
     fetchPollutionData(input$stations, input$chemical, input$date_range)
   })
   rain   <- reactive({
-    fetchRainData(input$date_range)
+    if(input$rain){ 
+      return(fetchRainData(input$date_range))
+    }
+    return(NULL)
   })
   future <- reactive({
     predictFuture(data())
@@ -52,7 +55,7 @@ server <- function(input, output) {
     fetchDayPollutionData(input$stations, input$chemical, day)
   })
   
-  output$plot1 <- renderPlot({renderTimeSeriesPlot(data(), rain(), future())})
+  output$plot1 <- renderPlot({renderTimeSeriesPlot(data(), rain(), future(), input$chemical)})
   output$plot2 <- renderPlot({renderDayTimeSeriesPlot(day_data())})
   output$map   <- renderLeaflet({renderMap(data())})
 }

--- a/exercise2/input_helpers.R
+++ b/exercise2/input_helpers.R
@@ -1,12 +1,17 @@
 library(DBI)
 
+stations <- NULL
+
 listOfStations <- function(){
-  db <- dbConnect(RSQLite::SQLite(), "data/air_pollution.db")
-  res <- dbSendQuery(db, "SELECT id, name FROM stations ORDER BY name")
-  chunk <- dbFetch(res)
-  dbClearResult(res)
-  dbDisconnect(db)
-  setNames(chunk$id, chunk$name)
+  if(is.null(stations)) {
+    db <- dbConnect(RSQLite::SQLite(), "data/air_pollution.db")
+    res <- dbSendQuery(db, "SELECT id, name FROM stations ORDER BY name")
+    chunk <- dbFetch(res)
+    dbClearResult(res)
+    dbDisconnect(db)
+    stations <- setNames(chunk$id, chunk$name)
+  }
+  stations
 }
 listOfChemicals <- function(){
   db <- dbConnect(RSQLite::SQLite(), "data/air_pollution.db")

--- a/exercise2/rain_helpers.R
+++ b/exercise2/rain_helpers.R
@@ -11,8 +11,9 @@ fetchRainData <- function(date_range){
   ## OUT: daily weather (Data, WindSpeedAvgKMH, PrecipitationSumCM)
   df<-getSummarizedWeather(stations_Madrid[1], start_date = date_range[1], date_range[2], station_type="id", opt_custom_columns=TRUE, custom_columns = cols)
   colnames(df)<- c("Date", "Rain")
-  print(df)
 
   df$Date=as.POSIXct(df$Date)
+  # drop last row
+  df = df[-nrow(df),]
   return(df)
   }

--- a/exercise2/scratchpad/sqlite.R
+++ b/exercise2/scratchpad/sqlite.R
@@ -7,3 +7,5 @@ res <- dbSendQuery(db, query)
 chunks <- dbFetch(res)
 chunks[['DATE(date)']]
 dbClearResult(res)
+
+x <- fetchPollutionData(c('28079016', '28079011'), 'NO', c('2014-12-01', '2015-01-01'))

--- a/exercise2/time_series_helpers.R
+++ b/exercise2/time_series_helpers.R
@@ -1,12 +1,56 @@
 library(reshape2)
 library(scales)
 
-renderTimeSeriesPlot <- function(data, rain, future){
-  #    ggplot(data=rain, aes(x=Date, y=Rain)) +geom_line()
+renderTimeSeriesPlot <- function(data, rain, future, chemical){
+  # set plot title
+  title <- paste(chemical, " levels",sep="")
+  
+  # find station names
+  n <- names(data)
+  l <- length(n)
+  n[2:l] = stationIdsToNames(n[2:l])
+  print(n)
+  data <- setNames(data, n)
+  
+  # Convert data to rate-of-change data if combined with rain data
+  if(!is.null(rain)) {
+    data$rain = rain$Rain
+    l <- length(data)
+    delta <- diff(as.matrix(data[2:l]))
+    data <- data[-nrow(data),]
+    data[2:l] <- delta / data[2:l]
+    
+    title <- paste("Rate-of-change for ", chemical, " and rainfall", sep="")
+  }
+  
+  # convert to ggplot consumable data
   data_long <- melt(data, id="date")
-  ggplot(data=data_long, aes(x=date, y=value, colour=variable, group=variable)) + 
+  data_long <- setNames(data_long, c('date', 'station', 'value'))
+  
+  plot <- ggplot(data=data_long, aes(x=date, y=value, colour=station, group=station)) + 
     geom_line() +
-    scale_x_date(date_minor_breaks = "1 day")
+    xlab('Date') + 
+    ylab(chemical) + 
+    theme(legend.justification = c(0, 1), legend.position = c(0, 1)) +
+    scale_x_date(date_minor_breaks = "1 day") +
+    ggtitle(title)
+  
+  # If rain, plot rate-of-change, so plot percentages
+  if(!is.null(rain)) {
+    plot <- plot + scale_y_continuous(labels = percent)
+  }
+  
+  return(plot)
+}
+
+stationIdsToNames <- function(ids) {
+  s <- listOfStations()
+  n <- names(s)
+  l <- length(ids)
+  for(i in 1:l) {
+    ids[[i]] <- n[s == ids[i]]
+  }
+  return(ids)
 }
 
 renderDayTimeSeriesPlot <- function(data) {


### PR DESCRIPTION
Adds rate of change when the user asks for rainfall data to be plotted.
This way the increase or decrease in `chemical` and `rain` can be better compared.

Also sets the graph labels, legend, and title correctly.